### PR TITLE
Use CurrentJDK symlink, not hardcoded version

### DIFF
--- a/FaceRecognitionJNI.xcodeproj/project.pbxproj
+++ b/FaceRecognitionJNI.xcodeproj/project.pbxproj
@@ -435,8 +435,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					/Library/Java/JavaVirtualMachines/jdk1.8.0_20.jdk/Contents/Home/include,
 					/usr/local/include,
+					"/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/TestJNI";
 				PRODUCT_MODULE_NAME = FaceRecognition;
@@ -453,8 +453,8 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					/Library/Java/JavaVirtualMachines/jdk1.8.0_20.jdk/Contents/Home/include,
 					/usr/local/include,
+					"/System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/TestJNI";
 				PRODUCT_MODULE_NAME = FaceRecognition;


### PR DESCRIPTION
I think this should be more reliable than using the hardcoded version number. Let me know if this doesn't work for you.
